### PR TITLE
Random Address Generation Bug Fix

### DIFF
--- a/x/bonds/handler.go
+++ b/x/bonds/handler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ixoworld/bonds/x/bonds/internal/keeper"
 	"github.com/ixoworld/bonds/x/bonds/internal/types"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/crypto/ed25519"
 	"strings"
 )
 
@@ -67,7 +66,7 @@ func handleMsgCreateBond(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgCre
 		return types.ErrBondTokenCannotBeStakingToken(DefaultCodeSpace).Result()
 	}
 
-	reserveAddress := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	reserveAddress := keeper.GetNextUnusedReserveAddress(ctx)
 
 	bond := NewBond(msg.Token, msg.Name, msg.Description, msg.Creator,
 		msg.FunctionType, msg.FunctionParameters, msg.ReserveTokens,

--- a/x/bonds/internal/keeper/bonds.go
+++ b/x/bonds/internal/keeper/bonds.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ixoworld/bonds/x/bonds/internal/types"
@@ -9,6 +10,42 @@ import (
 func (k Keeper) GetBondIterator(ctx sdk.Context) sdk.Iterator {
 	store := ctx.KVStore(k.storeKey)
 	return sdk.KVStorePrefixIterator(store, types.BondsKeyPrefix)
+}
+
+func (k Keeper) GetNumberOfBonds(ctx sdk.Context) sdk.Int {
+	count := sdk.ZeroInt()
+	iterator := k.GetBondIterator(ctx)
+	for ; iterator.Valid(); iterator.Next() {
+		var bond types.Bond
+		k.cdc.MustUnmarshalBinaryBare(iterator.Value(), &bond)
+		count = count.AddRaw(1)
+	}
+	return count
+}
+
+func (k Keeper) GetReserveAddressByBondCount(count sdk.Int) sdk.AccAddress {
+	var buffer bytes.Buffer
+
+	// Start with number of bonds prefixed with a letter (in this case, A)
+	// Letter is added to separate the number from possible digits
+	numString := "A" + count.String()
+
+	// Append numString to a base HEX address
+	buffer.WriteString("A97B2E13A94AF4A1D3EC729DC422C6341BAEEDC9")
+	buffer.WriteString(numString)
+
+	// Truncate from the front to the required length (38) and parse to address
+	truncated := buffer.String()[len(buffer.String())-40:]
+	res, err := sdk.AccAddressFromHex(truncated)
+	if err != nil {
+		panic(err)
+	}
+
+	return res
+}
+
+func (k Keeper) GetNextUnusedReserveAddress(ctx sdk.Context) sdk.AccAddress {
+	return k.GetReserveAddressByBondCount(k.GetNumberOfBonds(ctx))
 }
 
 func (k Keeper) GetBond(ctx sdk.Context, token string) (bond types.Bond, found bool) {

--- a/x/bonds/internal/keeper/bonds_test.go
+++ b/x/bonds/internal/keeper/bonds_test.go
@@ -16,7 +16,6 @@ func TestBondExistsSetGet(t *testing.T) {
 	// Bond doesn't exist yet
 	require.False(t, found)
 	require.False(t, app.BondsKeeper.BondExists(ctx, token))
-	require.False(t, app.BondsKeeper.BondExists(ctx, token))
 
 	// Add bond
 	bondAdded := getValidBond()

--- a/x/bonds/internal/keeper/bonds_test.go
+++ b/x/bonds/internal/keeper/bonds_test.go
@@ -38,6 +38,74 @@ func TestBondExistsSetGet(t *testing.T) {
 	require.True(t, found)
 }
 
+func TestGetNumberOfBonds(t *testing.T) {
+	app, ctx := createTestApp(false)
+
+	// No bond exists yet
+	require.Equal(t, sdk.ZeroInt(), app.BondsKeeper.GetNumberOfBonds(ctx))
+
+	// Add bond 1/3
+	app.BondsKeeper.SetBond(ctx, token1, getValidBondWithToken(token1))
+	require.Equal(t, sdk.NewInt(1), app.BondsKeeper.GetNumberOfBonds(ctx))
+
+	// Add bond 2/3
+	app.BondsKeeper.SetBond(ctx, token2, getValidBondWithToken(token2))
+	require.Equal(t, sdk.NewInt(2), app.BondsKeeper.GetNumberOfBonds(ctx))
+
+	// Add bond 3/3
+	app.BondsKeeper.SetBond(ctx, token3, getValidBondWithToken(token3))
+	require.Equal(t, sdk.NewInt(3), app.BondsKeeper.GetNumberOfBonds(ctx))
+}
+
+func TestGetReserveAddressByBondCount(t *testing.T) {
+	app, _ := createTestApp(false)
+	const maxInt64 = int64(^uint64(0) >> 1) // 9223372036854775807
+
+	testCases := []struct {
+		input        sdk.Int
+		truncatedHex string
+	}{
+		{sdk.NewInt(0), "7B2E13A94AF4A1D3EC729DC422C6341BAEEDC9A0"},
+		{sdk.NewInt(5), "7B2E13A94AF4A1D3EC729DC422C6341BAEEDC9A5"},
+		{sdk.NewInt(10), "B2E13A94AF4A1D3EC729DC422C6341BAEEDC9A10"},
+		{sdk.NewInt(50), "B2E13A94AF4A1D3EC729DC422C6341BAEEDC9A50"},
+		{sdk.NewInt(1000000000), "AF4A1D3EC729DC422C6341BAEEDC9A1000000000"},
+		{sdk.NewInt(5000000000), "AF4A1D3EC729DC422C6341BAEEDC9A5000000000"},
+		{sdk.NewInt(maxInt64), "729DC422C6341BAEEDC9A9223372036854775807"},
+	}
+
+	for _, tc := range testCases {
+		expectedAddr, err := sdk.AccAddressFromHex(tc.truncatedHex)
+		require.Nil(t, err)
+
+		addr := app.BondsKeeper.GetReserveAddressByBondCount(tc.input)
+		require.Equal(t, expectedAddr, addr)
+	}
+}
+
+func TestGetNextUnusedReserveAddress(t *testing.T) {
+	app, ctx := createTestApp(false)
+
+	testCases := []struct {
+		truncatedHex  string
+		nextBondToken string
+	}{
+		{"7B2E13A94AF4A1D3EC729DC422C6341BAEEDC9A0", token1},
+		{"7B2E13A94AF4A1D3EC729DC422C6341BAEEDC9A1", token2},
+		{"7B2E13A94AF4A1D3EC729DC422C6341BAEEDC9A2", token3},
+	}
+
+	for _, tc := range testCases {
+		expectedAddr, err := sdk.AccAddressFromHex(tc.truncatedHex)
+		require.Nil(t, err)
+
+		addr := app.BondsKeeper.GetNextUnusedReserveAddress(ctx)
+		require.Equal(t, expectedAddr, addr)
+
+		app.BondsKeeper.SetBond(ctx, tc.nextBondToken, getValidBondWithToken(tc.nextBondToken))
+	}
+}
+
 func TestGetReserveBalances(t *testing.T) {
 	app, ctx := createTestApp(false)
 

--- a/x/bonds/internal/keeper/common_test.go
+++ b/x/bonds/internal/keeper/common_test.go
@@ -11,6 +11,10 @@ import (
 var (
 	token = "testtoken"
 
+	token1 = "testtoken1"
+	token2 = "testtoken2"
+	token3 = "testtoken3"
+
 	blankSanityRate             = "0"
 	blankSanityMarginPercentage = "0"
 	reserveToken                = "res"
@@ -112,6 +116,13 @@ func getValidSwapperBond() types.Bond {
 
 func getValidBond() types.Bond {
 	return getValidPowerFunctionBond()
+}
+
+func getValidBondWithToken(token string) types.Bond {
+	bond := getValidPowerFunctionBond()
+	bond.Token = token
+	bond.MaxSupply = sdk.NewCoin(token, bond.MaxSupply.Amount)
+	return bond
 }
 
 func getValidBatch() types.Batch {


### PR DESCRIPTION
This MR solves the issue that on-the-fly random address generation was being used for reserve addresses. This works with no problems in a single-node environment but in a network of nodes, each node will generate a random address, thus breaking the determinism of the chain.

Closes #5 