### PR TITLE
typo in input command

### DIFF
--- a/tutorials/01_standard.md
+++ b/tutorials/01_standard.md
@@ -87,7 +87,7 @@ bondscli tx bonds create-bond \
   --allow-sells \
   --signers="$SHAUNADDR" \
   --batch-blocks=2 \
-  --outcome_payment="" \
+  --outcome-payment="" \
   --from shaun \
   --keyring-backend=test \
   --broadcast-mode block \


### PR DESCRIPTION
underscore instead of hyphen